### PR TITLE
fix: streamline with vim.ui.select; add stylua

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,6 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferDouble"
+no_call_parentheses = true

--- a/lua/telescope/_extensions/ui-select.lua
+++ b/lua/telescope/_extensions/ui-select.lua
@@ -11,8 +11,12 @@ return require("telescope").register_extension {
     local action_state = require "telescope.actions.state"
 
     vim.ui.select = function(items, opts, on_choice)
+      opts = opts or {}
+      opts.format_item = vim.F.if_nil(opts.format_item, function(e)
+        return e
+      end)
       pickers.new(topts, {
-        prompt_title = opts.prompt,
+        prompt_title = vim.F.if_nil(opts.prompt, "Select one of"),
         finder = finders.new_table {
           results = items,
           entry_maker = function(e)
@@ -25,9 +29,11 @@ return require("telescope").register_extension {
         },
         attach_mappings = function(prompt_bufnr)
           actions.select_default:replace(function()
-            actions.close(prompt_bufnr)
             local selection = action_state.get_selected_entry().value
-            on_choice(selection)
+            local current_picker = action_state.get_current_picker(prompt_bufnr)
+            local selection_index = current_picker:get_index(current_picker:get_selection_row())
+            actions.close(prompt_bufnr)
+            on_choice(selection, selection_index)
           end)
           return true
         end,


### PR DESCRIPTION
Streamlines a few things:
- `opts` or its keys may be `nil` -- we now default to what `vim.ui.select` does
- `on_choice` should accept `idx` like `vim.ui.select`
- added stylua from `core` bc I was confused what happened when I formatted otherwise :laughing: -- let me know if you prefer that in a separate commit