### PR TITLE
Fix bug where filtering items is returning wrong index

### DIFF
--- a/lua/telescope/_extensions/ui-select.lua
+++ b/lua/telescope/_extensions/ui-select.lua
@@ -12,28 +12,30 @@ return require("telescope").register_extension {
 
     vim.ui.select = function(items, opts, on_choice)
       opts = opts or {}
+      local indexed_items = {}
+      for idx, item in ipairs(items) do
+        table.insert(indexed_items, {index = idx, text = item})
+      end
       opts.format_item = vim.F.if_nil(opts.format_item, function(e)
         return e
       end)
       pickers.new(topts, {
         prompt_title = vim.F.if_nil(opts.prompt, "Select one of"),
         finder = finders.new_table {
-          results = items,
+          results = indexed_items,
           entry_maker = function(e)
             return {
               value = e,
-              display = opts.format_item(e),
-              ordinal = opts.format_item(e),
+              display = opts.format_item(e.text),
+              ordinal = opts.format_item(e.text),
             }
           end,
         },
         attach_mappings = function(prompt_bufnr)
           actions.select_default:replace(function()
             local selection = action_state.get_selected_entry().value
-            local current_picker = action_state.get_current_picker(prompt_bufnr)
-            local selection_index = current_picker:get_index(current_picker:get_selection_row())
             actions.close(prompt_bufnr)
-            on_choice(selection, selection_index)
+            on_choice(selection.text, selection.index)
           end)
           return true
         end,


### PR DESCRIPTION
This PR should fix a bug where filtering the options is returning the wrong index (text and index doesn't correspond to each other), here's a simple reproducible example

```lua
local options = { "AD", "AB", "AC", "CC", "BB" }
vim.ui.select(options, { prompt = "Select Command: " }, function(command, index)
  print(string.format("command: %s - index: %s - command_index: %s", command, index, options[index]))
end)
```

These two gifs show the bug & fix

![bug](https://user-images.githubusercontent.com/16278108/156393973-42c59289-3ad7-427d-94a1-4dc622732e05.gif)

![fix](https://user-images.githubusercontent.com/16278108/156393993-8db789a9-b673-4529-a70b-70598bec28f5.gif)

