### PR TITLE
Fix error when called with `prompt` containing newlines

### DIFF
--- a/lua/telescope/_extensions/ui-select.lua
+++ b/lua/telescope/_extensions/ui-select.lua
@@ -100,7 +100,7 @@ return require("telescope").register_extension {
         return opts.format_item(e.text)
       end)
       pickers.new(topts, {
-        prompt_title = prompt,
+        prompt_title = string.gsub(prompt, "\n", " "),
         finder = finders.new_table {
           results = indexed_items,
           entry_maker = function(e)


### PR DESCRIPTION
Closes #19

I'm not sure if `format_item` will also need a patch, but my rudimentary tests show that it does seem to cope with newlines at least somewhat in its current state.