### PR TITLE
fix: bump codeaction version requirement

### DIFF
--- a/lua/telescope/_extensions/ui-select.lua
+++ b/lua/telescope/_extensions/ui-select.lua
@@ -29,7 +29,7 @@ return require("telescope").register_extension {
             }
             for idx, item in ipairs(items) do
               local client_id, title
-              if vim.version and vim.version.cmp(vim.version(), vim.version.parse "0.10-dev") >= 0 then
+              if vim.version and vim.version.cmp(vim.version(), vim.version.parse "0.10.1-dev") >= 0 then
                 client_id = item.ctx.client_id
                 title = item.action.title
               else


### PR DESCRIPTION
Fixes issue where it throws error on version 10.0 as described in this issue: https://github.com/nvim-telescope/telescope-ui-select.nvim/issues/29