### PR TITLE
[backwards-compatibility] Prevent error messages from incorrect usage by 3rd party plugins

### DIFF
--- a/lua/telescope/_extensions/ui-select.lua
+++ b/lua/telescope/_extensions/ui-select.lua
@@ -28,8 +28,23 @@ return require("telescope").register_extension {
               client_name = 0,
             }
             for idx, item in ipairs(items) do
-              local client_id = item[1]
-              local title = item[2].title
+              local client_id, title
+
+              if item[1] ~= nil and item[2] ~= nil and item[2].title ~= nil then
+                client_id = item[1]
+                title = item[2].title
+              elseif
+                item.ctx ~= nil
+                and item.ctx.client_id ~= nil
+                and item.action ~= nil
+                and item.action.title ~= nil
+              then
+                client_id = item.ctx.client_id
+                title = item.action.title
+              else
+                vim.api.nvim_err_writeln "telescope-ui-select.nvim - Failed to get code action information"
+              end
+
               local client = vim.lsp.get_client_by_id(client_id)
 
               local entry = {

--- a/lua/telescope/_extensions/ui-select.lua
+++ b/lua/telescope/_extensions/ui-select.lua
@@ -28,15 +28,8 @@ return require("telescope").register_extension {
               client_name = 0,
             }
             for idx, item in ipairs(items) do
-              local client_id, title
-              if vim.version and vim.version.cmp(vim.version(), vim.version.parse "0.10-dev") >= 0 then
-                client_id = item.ctx.client_id
-                title = item.action.title
-              else
-                client_id = item[1]
-                title = item[2].title
-              end
-
+              local client_id = item[1]
+              local title = item[2].title
               local client = vim.lsp.get_client_by_id(client_id)
 
               local entry = {

--- a/lua/telescope/_extensions/ui-select.lua
+++ b/lua/telescope/_extensions/ui-select.lua
@@ -42,7 +42,7 @@ return require("telescope").register_extension {
                 client_id = item.ctx.client_id
                 title = item.action.title
               else
-                vim.api.nvim_err_writeln "telescope-ui-select.nvim - Failed to get code action information"
+                vim.api.nvim_err_writeln "telescope-ui-select.nvim - Failed to get item information"
               end
 
               local client = vim.lsp.get_client_by_id(client_id)


### PR DESCRIPTION
This might be out-of-scope for this project, but this change would allow for backwards-compatibility with old nvim 0.9 plugins.

Ideally these plugins would be updated themselves, but in the mean time, this change would fix version incompatibility from both the usage and calling sides of the api.